### PR TITLE
taking out unnecessary examples

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,11 +2,12 @@ Package: RealHomePrice
 Title: Predicting Home Price 
 Version: 0.0.0.9000
 Authors@R: 
-    person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
-           comment = c(ORCID = "YOUR-ORCID-ID"))
+    person("Russell", "Marvin", , "marvinru@mail.gvsu.edu", role = c("aut", "cre"))
+    person("Moreen", "Owino", , "owinom@mail.gvsu.edu", role = c("aut", "cre"))
+    person("Bipin", "Parajuli", , "parajubi@mail.gvsu.edu", role = c("aut", "cre"))
+    person("Nicholas", "Scholl", , "scholln@mail.gvsu.edu", role = c("aut", "cre"))
 Description: This package will use a multiple linear regression model and a neural net to predict your home price. It uses data from https://www.kaggle.com/datasets/ahmedshahriarsakib/usa-real-estate-dataset to train these models. The predict_Price function takes in a dataframe of your input values (bed, bath, house_size) and returns a predicted price to serveas a reference point for your home price. 
-License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
-    license
+License: use_gpl_lisence()
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.2

--- a/R/normalize_input.R
+++ b/R/normalize_input.R
@@ -2,9 +2,7 @@
 #'
 #' @param x  user data in a dataframe, numeric values
 #' @returns dataframe of normalized user input
-#' @examples
-#' example_user_data <- data.frame(c(3),c(2),c(1100))
-#' normalize_input(example_user_data)
+#' 
 #' @export
 
 

--- a/R/predict_lm.R
+++ b/R/predict_lm.R
@@ -3,18 +3,9 @@
 #' @param x Normalized user data in a dataframe, numeric values
 #' @returns unscaled predicted price
 #'
-#' @examples
-#' example_normalized_user_data <- data.frame(c(#INSERT),c(#NORM),c(#DATA))
-#' predict_lm(example_normalized_user_data)
 #' @export
 
-<<<<<<< HEAD
-predict_lm <- function(nor_User_data) {
-  linear_model_fit <- load("pricemodel.R")
-  predict(linear_model_fit, nor_User_data)
-=======
 predict_lm <- function(x) {
-  linear_model_fit <- readRDS("pricemodel.rds")
+  linear_model_fit <- load("linear_model_fit.R")
   predict(linear_model_fit, x)
->>>>>>> 89c177b2dbfaeec4129aaaa2b982bbde8c512c02
 }

--- a/R/predict_nn.R
+++ b/R/predict_nn.R
@@ -3,12 +3,9 @@
 #' @param x Normalized user data in a dataframe
 #' @returns unscaled predicted price
 #'
-#' @examples
-#' example_normalized_user_data <- data.frame(c(#INSERT),c(#NORM),c(#DATA))
-#' predict_nn(example_normalized_user_data)
 #' @export
 
 predict_nn <- function(x) {
-  neural_net_fit <- readRDS("neural_net_fit.rds")
+  neural_net_fit <- load("pricemodel.R")
   predict(neural_net_fit, x)
 }

--- a/R/unscale_price.R
+++ b/R/unscale_price.R
@@ -2,10 +2,7 @@
 #'
 #' @param x  predicted price by the model
 #' @returns unscaled prediction
-
-#' @examples 
-#' example_normalized_user_price <- data.frame(c(#INSERT PRICE))
-#' unscale_price(example_normalized_user_price)
+#' 
 #' @export
 unscale_price <- function(x) {
   x*(max(cleaned_realtordata$price))+min(cleaned_realtordata$price)


### PR DESCRIPTION
I took out the examples and changed the linear_model_fit object to load linear_model_fit.R instead of pricemodel.R - I think that is the neural net one? Similar change with neural_net_fit, which now calls load("pricemodel.R"), which is the neural net fit, instead of the .rds file.